### PR TITLE
Handle quiet pytest summaries

### DIFF
--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -212,8 +212,14 @@ def _parse_pytest_summary(output: str) -> Dict[str, int]:
 
     summary_line: Optional[str] = None
     for line in reversed(output.splitlines()):
-        if line.strip().startswith("===") and " in " in line:
-            summary_line = line.strip("= \n")
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("===") and " in " in stripped:
+            summary_line = stripped.strip("= ").strip()
+            break
+        if re.match(r"^\d+ [A-Za-z_-]+(?:, \d+ [A-Za-z_-]+)* in .+$", stripped):
+            summary_line = stripped
             break
 
     if not summary_line:

--- a/tests/test_pipeline_helpers.py
+++ b/tests/test_pipeline_helpers.py
@@ -35,6 +35,14 @@ def test_parse_pytest_summary_handles_failures() -> None:
     assert counts["errors"] == 2
 
 
+def test_parse_pytest_summary_quiet_output() -> None:
+    summary = "5 passed, 1 skipped, 2 warnings in 0.12s"
+    counts = _parse_pytest_summary(summary)
+    assert counts["passed"] == 5
+    assert counts["skipped"] == 1
+    assert counts["warnings"] == 2
+
+
 def test_build_install_commands_infers_requirements(tmp_path: Path) -> None:
     (tmp_path / "requirements.txt").write_text("pytest\n")
     (tmp_path / "pyproject.toml").write_text(


### PR DESCRIPTION
## Summary
- update the pytest summary parser to recognise quiet-mode summary lines
- cover the quiet-mode parsing branch with a dedicated unit test

## Testing
- pytest tests/test_pipeline_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68da5e2e209c8326a61c168f63081749